### PR TITLE
No Mixpanel for dev?

### DIFF
--- a/convox/helpers.go
+++ b/convox/helpers.go
@@ -17,6 +17,9 @@ func exists(filename string) bool {
 }
 
 func sendMixpanelEvent(event string) {
+	if os.Getenv("DEVELOPMENT") == "Yes" {
+		return // don't log dev events
+	}
 	id, err := currentId()
 
 	if err != nil {


### PR DESCRIPTION
I've been firing a fair few deploys while prototyping some things. 
I'm warey that's probably quite noisy over at Mixpanel (and Rollbar sometimes!) 

This PR skips MixPanel if ENV `DEVELOPMENT=Yes` if you wish.

