### PR TITLE
cleanup creds and host when uninstalling

### DIFF
--- a/convox/install.go
+++ b/convox/install.go
@@ -355,9 +355,9 @@ func cmdUninstall(c *cli.Context) {
 	}
 
 	if configuredHost, _ := currentHost(); configuredHost == host {
-		remHost()
+		removeHost()
 	}
-	remLogin(host)
+	removeLogin(host)
 
 	fmt.Println("Successfully uninstalled.")
 

--- a/convox/login.go
+++ b/convox/login.go
@@ -213,6 +213,34 @@ func addLogin(host, password string) error {
 	return ioutil.WriteFile(config, data, 0600)
 }
 
+func remLogin(host string) error {
+	config := filepath.Join(ConfigRoot, "auth")
+
+	data, _ := ioutil.ReadFile(filepath.Join(config))
+
+	if data == nil {
+		data = []byte("{}")
+	}
+
+	var auth ConfigAuth
+
+	err := json.Unmarshal(data, &auth)
+
+	if err != nil {
+		return err
+	}
+
+	delete(auth, host)
+
+	data, err = json.Marshal(auth)
+
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(config, data, 0600)
+}
+
 func switchHost(host string) error {
 	return ioutil.WriteFile(filepath.Join(ConfigRoot, "host"), []byte(host), 0600)
 }

--- a/convox/login.go
+++ b/convox/login.go
@@ -213,7 +213,7 @@ func addLogin(host, password string) error {
 	return ioutil.WriteFile(config, data, 0600)
 }
 
-func remLogin(host string) error {
+func removeLogin(host string) error {
 	config := filepath.Join(ConfigRoot, "auth")
 
 	data, _ := ioutil.ReadFile(filepath.Join(config))
@@ -245,7 +245,7 @@ func switchHost(host string) error {
 	return ioutil.WriteFile(filepath.Join(ConfigRoot, "host"), []byte(host), 0600)
 }
 
-func remHost() error {
+func removeHost() error {
 	err := os.Remove(filepath.Join(ConfigRoot, "host"))
 
 	if err != nil {

--- a/convox/login.go
+++ b/convox/login.go
@@ -217,6 +217,15 @@ func switchHost(host string) error {
 	return ioutil.WriteFile(filepath.Join(ConfigRoot, "host"), []byte(host), 0600)
 }
 
+func remHost() error {
+	err := os.Remove(filepath.Join(ConfigRoot, "host"))
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func currentLogin() (string, string, error) {
 	host, err := currentHost()
 


### PR DESCRIPTION
There's no clean up of login after uninstall.
https://github.com/convox/cli/blob/master/convox/install.go#L200-L201

Therefore:

```shell
$ STACK_NAME=convox-ap-34 convox uninstall
...
Successfully uninstalled.
$ convox logs
ERROR: websocket.Dial wss://convox-ap-34-2121175072.ap-southeast-2.elb.amazonaws.com/apps/cli/logs/stream: dial tcp: lookup convox-ap-34-2121175072.ap-southeast-2.elb.amazonaws.com: no such host
```

This PR:

* Adds `remLogin` to delete the specified hosts login.
* Adds `remHost` to delete the host association.
* Infers `host` when uninstalling from the stack that's being uninstalled.
* Adds `remLogin` and `remHost` to the uninstall command, conditionally uses `remHost` if the uninstalled host is the current one. (prompting a login next run of `convox` cli)

```shell
$ STACK_NAME=convox-rm-host convox uninstall
...
Successfully uninstalled.
$ convox logs
ERROR: must login first
```

I think it would be prudent to hold stack name in the `auth` file JSON but don't want to break compat. 
