### PR TITLE
apps: switch colon to dots

### DIFF
--- a/convox/apps.go
+++ b/convox/apps.go
@@ -82,9 +82,9 @@ func cmdAppCreate(c *cli.Context) {
 	}
 
 	if app == "" {
-		fmt.Printf("Creating app: ")
+		fmt.Printf("Creating app... ")
 	} else {
-		fmt.Printf("Creating app %s: ", app)
+		fmt.Printf("Creating app %s... ", app)
 	}
 
 	v := url.Values{}
@@ -142,7 +142,7 @@ func cmdAppDelete(c *cli.Context) {
 
 	app := c.Args()[0]
 
-	fmt.Printf("Deleting %s: ", app)
+	fmt.Printf("Deleting %s... ", app)
 
 	_, err := ConvoxDelete(fmt.Sprintf("/apps/%s", app))
 

--- a/convox/apps_test.go
+++ b/convox/apps_test.go
@@ -50,7 +50,7 @@ func TestAppsCreate(t *testing.T) {
 
 	stdout, stderr := appRun([]string{"convox", "apps", "create", "foobar"})
 
-	expect(t, stdout, "Creating app foobar: OK\n")
+	expect(t, stdout, "Creating app foobar... OK\n")
 	expect(t, stderr, "")
 }
 
@@ -64,6 +64,6 @@ func TestAppsCreateFail(t *testing.T) {
 
 	stdout, stderr := appRun([]string{"convox", "apps", "create", "foobar"})
 
-	expect(t, stdout, "Creating app foobar: ")
+	expect(t, stdout, "Creating app foobar... ")
 	expect(t, stderr, "ERROR: app already exists\n")
 }


### PR DESCRIPTION
Currently when performing some functions on apps, while waiting the output is a colon - it feels just like it's waiting for input.

```shell
$ convox apps create
Creating app test-app:
# pause for processing then
Creating app test-app: OK
```

This PR changes it to `...` which is more consistent with output in build/release commands too.

```shell
$ convox apps create
Creating app test-app...
# pause for processing then
Creating app test-app... OK
```