### PR TITLE
Configurable Regions - Simplified

### DIFF
--- a/convox/install.go
+++ b/convox/install.go
@@ -44,6 +44,12 @@ func init() {
 				Value: "t2.small",
 				Usage: "type of EC2 instances",
 			},
+			cli.StringFlag{
+				Name: "region",
+				Value: "us-east-1",
+				Usage: "aws region to install in",
+				EnvVar: "AWS_REGION",
+			},
 		},
 	})
 
@@ -90,7 +96,7 @@ func cmdInstall(c *cli.Context) {
 	fmt.Println("install process and then delete them once the installer has completed.")
 	fmt.Println("")
 	fmt.Println("To generate a new set of AWS credentials go to:")
-	fmt.Println("https://console.aws.amazon.com/iam/home?region=us-east-1#security_credential")
+	fmt.Println("https://console.aws.amazon.com/iam/home#security_credential")
 	fmt.Println("")
 
 	distinctId, err := currentId()
@@ -157,7 +163,7 @@ func cmdInstall(c *cli.Context) {
 	password := randomString(30)
 
 	CloudFormation := cloudformation.New(&aws.Config{
-		Region:      "us-east-1",
+		Region:      c.String("region"),
 		Credentials: credentials.NewStaticCredentials(access, secret, ""),
 	})
 
@@ -232,7 +238,7 @@ func cmdUninstall(c *cli.Context) {
 	fmt.Println("uninstall process and then delete them once the uninstaller has completed.")
 	fmt.Println("")
 	fmt.Println("To generate a new set of AWS credentials go to:")
-	fmt.Println("https://console.aws.amazon.com/iam/home?region=us-east-1#security_credential")
+	fmt.Println("https://console.aws.amazon.com/iam/home#security_credential")
 	fmt.Println("")
 
 	reader := bufio.NewReader(os.Stdin)
@@ -276,7 +282,7 @@ func cmdUninstall(c *cli.Context) {
 	secret = strings.TrimSpace(secret)
 
 	CloudFormation := cloudformation.New(&aws.Config{
-		Region:      "us-east-1",
+		Region:      c.String("region"),
 		Credentials: credentials.NewStaticCredentials(access, secret, ""),
 	})
 
@@ -313,7 +319,7 @@ func cmdUninstall(c *cli.Context) {
 	fmt.Printf("Cleaning up registry...\n")
 
 	S3 := s3.New(&aws.Config{
-		Region:      "us-east-1",
+		Region:      c.String("region"),
 		Credentials: credentials.NewStaticCredentials(access, secret, ""),
 	})
 


### PR DESCRIPTION
Based on #47 - we needed to use Convox in `eu-west-1` which currently does support Lambda and all other features out of the box. We think it'd be useful to merge this in first, pending the more complex work in #47.

The only thing this would require is a `formation.zip` in every region. Perhaps you could create buckets for `convox-us`, `convox-eu` etc. for this? We've currently copied the `.zip` into our own S3 bucket (and therefore the formation.json too) but clearly those will become outdated soon.

Thanks for your work. It's great!