### PR TITLE
convox deploy with app name that differs from directory

### DIFF
--- a/convox/build.go
+++ b/convox/build.go
@@ -69,6 +69,7 @@ func executeBuild(dir string, app string) (string, error) {
 		stdcli.Error(err)
 	}
 
+	fmt.Printf("Deploying %s\n", app)
 	fmt.Print("Uploading... ")
 
 	tar, err := createTarball(dir)
@@ -224,9 +225,9 @@ func waitForBuild(app, id string) (string, error) {
 		case "complete":
 			return build.Release, nil
 		case "error":
-			return "", fmt.Errorf("build failed")
+			return "", fmt.Errorf("%s build failed", app)
 		case "failed":
-			return "", fmt.Errorf("build failed")
+			return "", fmt.Errorf("%s build failed", app)
 		}
 
 		time.Sleep(1 * time.Second)

--- a/convox/releases.go
+++ b/convox/releases.go
@@ -123,7 +123,7 @@ func cmdReleasePromote(c *cli.Context) {
 }
 
 func postRelease(app, release string) (*App, error) {
-	fmt.Print("Releasing... ")
+	fmt.Printf("Releasing %s... ", app)
 
 	// promote release
 	_, err := ConvoxPost(fmt.Sprintf("/apps/%s/releases/%s/promote", app, release), "")


### PR DESCRIPTION
It's non-obvious when deploying that the app name is inferred from the directory.

```shell
$ pwd
/Users/rjocoleman/Code/test-convox

$ convox apps
APP            STATUS
test-convox          running

$ convox apps create test-convox-3
Creating app test-convox-3... OK

$ convox deploy
Uploading... OK
RUNNING: docker build -t teicjsjldd /tmp/repo288982807/clone
Sending build context to Docker daemon  89.6 kB
-- snip --
ERROR: build failed
```

The build might not fail. Either way I think the following additions would be helpful:

```shell
$ convox deploy
Deploying app test-convox
Uploading... OK
-- snip --
ERROR: test-convox build failed
-- or --
Releasing test-convox... OK, 
Waiting for app... OK
```

The way to deploy this app correctly is `convox deploy --app test-convox-3`