### PR TITLE
print msg to stderr and retry on websocket hiccups

### DIFF
--- a/convox/build.go
+++ b/convox/build.go
@@ -196,7 +196,8 @@ func streamBuild(app, build string) error {
 		err := websocket.Message.Receive(ws, &message)
 
 		if err != nil {
-			break
+			fmt.Fprintf(os.Stderr, "ws %s, retrying...\n", err.Error())
+			streamBuild(app, build)
 		}
 
 		fmt.Print(string(message))

--- a/convox/logs.go
+++ b/convox/logs.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/convox/cli/Godeps/_workspace/src/golang.org/x/net/websocket"
 
@@ -78,11 +79,15 @@ func cmdLogsStream(c *cli.Context) {
 			err := websocket.Message.Receive(ws, &message)
 
 			if err == io.EOF {
+				fmt.Fprintf(os.Stderr, "ws %s, retrying...\n", err.Error())
+				cmdLogsStream(c)
 				return
 			}
 
 			if err != nil {
-				break
+				fmt.Fprintf(os.Stderr, "ws %s, retrying...\n", err.Error())
+				cmdLogsStream(c)
+				return
 			}
 
 			fmt.Print(string(message))


### PR DESCRIPTION
I've noticed and gotten lots of reports of logs not working. Adding a retry to the websocket on errors seems to help quite a bit.

We don't necessarily need to print the debugging 'ws EOF, retrying...' message, but it feels helpful for now.