### PR TITLE
Builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+*.swp
 .equinox.yaml
 convox/convox

--- a/convox/build.go
+++ b/convox/build.go
@@ -69,7 +69,6 @@ func executeBuild(dir string, app string) (string, error) {
 		stdcli.Error(err)
 	}
 
-	fmt.Printf("Deploying %s\n", app)
 	fmt.Print("Uploading... ")
 
 	tar, err := createTarball(dir)

--- a/convox/build.go
+++ b/convox/build.go
@@ -195,12 +195,11 @@ func streamBuild(app, build string) error {
 		err := websocket.Message.Receive(ws, &message)
 
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "ws %s, retrying...\n", err.Error())
-			streamBuild(app, build)
+			break
 		}
-
-		fmt.Print(string(message))
 	}
+
+	fmt.Print(string(message))
 
 	return nil
 }

--- a/convox/builds.go
+++ b/convox/builds.go
@@ -54,17 +54,12 @@ func cmdBuilds(c *cli.Context) {
 		return
 	}
 
-	longest := 7
-
-	fmt.Printf(fmt.Sprintf("%%-12s  %%-%ds  %%-11s  %%-5s  %%s\n", longest), "ID", "RELEASE", "STATUS", "STARTED", "ENDED")
-
-	var started Time
-	var ended Time
+	fmt.Printf("%-12s  %-12s  %-9s  %-22s  %s\n", "ID", "RELEASE", "STATUS", "STARTED", "ENDED")
 
 	for _, build := range builds {
-		started = build.Started
-		ended = build.Ended
-		fmt.Printf(fmt.Sprintf("%%-12s  %%-%ds  %%-11s  %%-5d  %%s\n", longest), build.Id, build.Release, started.Format(time.RFC822Z), ended.Format(time.RFC822Z), build.Ended)
+		started := build.Started
+		ended := build.Ended
+		fmt.Printf("%-12s  %-12s  %-9s  %-22s  %s\n", build.Id, build.Release, build.Status, started.Format(time.RFC822Z), ended.Format(time.RFC822Z))
 	}
 }
 

--- a/convox/builds.go
+++ b/convox/builds.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/convox/cli/Godeps/_workspace/src/github.com/codegangsta/cli"
+	"github.com/convox/cli/stdcli"
+)
+
+func init() {
+	stdcli.RegisterCommand(cli.Command{
+		Name:        "builds",
+		Description: "manage an app's builds",
+		Usage:       "",
+		Action:      cmdBuilds,
+		Flags:       []cli.Flag{appFlag},
+		Subcommands: []cli.Command{
+			{
+				Name:        "create",
+				Description: "create a new build",
+				Usage:       "",
+				Action:      cmdBuildsCreate,
+				Flags:       []cli.Flag{appFlag},
+			},
+		},
+	})
+}
+
+func cmdBuilds(c *cli.Context) {
+	_, app, err := stdcli.DirApp(c, ".")
+
+	if err != nil {
+		stdcli.Error(err)
+		return
+	}
+
+	path := fmt.Sprintf("/apps/%s/builds", app)
+
+	resp, err := ConvoxGet(path)
+
+	if err != nil {
+		stdcli.Error(err)
+		return
+	}
+
+	var builds []Build
+
+	err = json.Unmarshal(resp, &builds)
+
+	if err != nil {
+		stdcli.Error(err)
+		return
+	}
+
+	longest := 7
+
+	fmt.Printf(fmt.Sprintf("%%-12s  %%-%ds  %%-11s  %%-5s  %%s\n", longest), "ID", "RELEASE", "STATUS", "STARTED", "ENDED")
+
+	var started Time
+	var ended Time
+
+	for _, build := range builds {
+		started = build.Started
+		ended = build.Ended
+		fmt.Printf(fmt.Sprintf("%%-12s  %%-%ds  %%-11s  %%-5d  %%s\n", longest), build.Id, build.Release, started.Format(time.RFC822Z), ended.Format(time.RFC822Z), build.Ended)
+	}
+}
+
+func cmdBuildsCreate(c *cli.Context) {
+}

--- a/convox/builds.go
+++ b/convox/builds.go
@@ -64,4 +64,30 @@ func cmdBuilds(c *cli.Context) {
 }
 
 func cmdBuildsCreate(c *cli.Context) {
+	wd := "."
+
+	if len(c.Args()) > 0 {
+		wd = c.Args()[0]
+	}
+
+	dir, app, err := stdcli.DirApp(c, wd)
+
+	if err != nil {
+		stdcli.Error(err)
+		return
+	}
+
+	_, err = ConvoxGet(fmt.Sprintf("/apps/%s", app))
+
+	if err != nil {
+		stdcli.Error(err)
+		return
+	}
+
+	_, err = executeBuild(dir, app)
+
+	if err != nil {
+		stdcli.Error(err)
+		return
+	}
 }

--- a/convox/builds.go
+++ b/convox/builds.go
@@ -91,5 +91,5 @@ func cmdBuildsCreate(c *cli.Context) {
 		return
 	}
 
-	fmt.Sprintln("Build complete. Release ID: %s", release)
+	fmt.Printf("Build complete.\nRelease ID: %s\n", release)
 }

--- a/convox/builds.go
+++ b/convox/builds.go
@@ -84,10 +84,12 @@ func cmdBuildsCreate(c *cli.Context) {
 		return
 	}
 
-	_, err = executeBuild(dir, app)
+	release, err := executeBuild(dir, app)
 
 	if err != nil {
 		stdcli.Error(err)
 		return
 	}
+
+	fmt.Sprintln("Build complete. Release ID: %s", release)
 }

--- a/convox/deploy.go
+++ b/convox/deploy.go
@@ -38,6 +38,8 @@ func cmdDeploy(c *cli.Context) {
 		return
 	}
 
+	fmt.Printf("Deploying %s\n", app)
+
 	_, err = ConvoxGet(fmt.Sprintf("/apps/%s", app))
 
 	if err != nil {


### PR DESCRIPTION
This PR adds a `convox builds` command to list Builds plus a `convox builds create` subcommand to create a build but not deploy.

It removes the websocket reconnect logic from the `executeBuild` function. It would get in an infinite loop on EOF at the end of the build and print the logs over and over again. `executeBuild` is also used by `convox deploy`, so  it will no longer automatically reconnect.

Fixes #100.