### PR TITLE
add Custom::KMSKey to friendlyName

### DIFF
--- a/convox/install.go
+++ b/convox/install.go
@@ -563,6 +563,8 @@ func friendlyName(t string) string {
 		return "ECS Service"
 	case "Custom::S3BucketCleanup":
 		return ""
+	case "Custom::KMSKey":
+		return "KMS Key"
 	}
 
 	return fmt.Sprintf("Unknown: %s", t)


### PR DESCRIPTION
This PR adds `Custom::KMSKey` to the list of known/translated resources.

Currently:

```
Installing Convox...
[snip]
Created VPC Subnet: subnet-9185d9c8,subnet-d7da9afc,subnet-4a3e3b3d,subnet-68659055
Created Kinesis Stream: tc-9-Kinesis-1CSHDZ4ICTDTA
Created Unknown: Custom::KMSKey: EncryptionKey
Created DynamoDB Table: tc-9-releases
```

Now:

```
Installing Convox...
[snip]
Created VPC Subnet: subnet-9185d9c8,subnet-d7da9afc,subnet-4a3e3b3d,subnet-68659055
Created Kinesis Stream: tc-9-Kinesis-1CSHDZ4ICTDTA
Created KMS Key: EncryptionKey
Created DynamoDB Table: tc-9-releases
```