### PR TITLE
Cluster Top

### DIFF
--- a/convox/top.go
+++ b/convox/top.go
@@ -71,5 +71,9 @@ func getMetrics(name string) (*Datapoint, error) {
 		return nil, err
 	}
 
+	if len(ms.Datapoints) == 0 {
+		return nil, fmt.Errorf("No %s data available", name)
+	}
+
 	return &ms.Datapoints[0], nil
 }

--- a/convox/top.go
+++ b/convox/top.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/convox/cli/Godeps/_workspace/src/github.com/codegangsta/cli"
+	"github.com/convox/cli/stdcli"
+)
+
+type Datapoint struct {
+	Average     float64
+	Maximum     float64
+	Minimum     float64
+	SampleCount float64
+	Sum         float64
+	Timestamp   time.Time
+	Unit        string
+}
+
+type MetricStatistics struct {
+	Datapoints []Datapoint
+	Label      string
+}
+
+func init() {
+	stdcli.RegisterCommand(cli.Command{
+		Name:        "top",
+		Action:      cmdTop,
+		Description: "resource utilization stats",
+		Usage:       "",
+	})
+}
+
+func cmdTop(c *cli.Context) {
+	data, err := ConvoxGet("/top")
+
+	if err != nil {
+		stdcli.Error(err)
+		return
+	}
+
+	var ms MetricStatistics
+
+	err = json.Unmarshal(data, &ms)
+
+	if err != nil {
+		stdcli.Error(err)
+		return
+	}
+
+	dp := ms.Datapoints[0]
+
+	ps := "%.1f"
+	fmt.Println("MAX    AVG    MIN")
+	fmt.Printf("%-5s  %-5s  %-5s\n", fmt.Sprintf(ps, dp.Maximum), fmt.Sprintf(ps, dp.Average), fmt.Sprintf(ps, dp.Minimum))
+}
+
+func round(f float64) float64 {
+	return math.Floor(f + .5)
+}

--- a/convox/top.go
+++ b/convox/top.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"time"
 
 	"github.com/convox/cli/Godeps/_workspace/src/github.com/codegangsta/cli"
@@ -35,11 +34,33 @@ func init() {
 }
 
 func cmdTop(c *cli.Context) {
-	data, err := ConvoxGet("/top")
+	metrics := []string{"CPUUtilization", "MemoryUtilization"}
+	labels := []string{"CPU", "MEM"}
+
+	fmt.Println("     MAX    AVG    MIN    UPDATED")
+
+	for i := 0; i < len(metrics); i++ {
+		dp, err := getMetrics(metrics[i])
+
+		if err != nil {
+			stdcli.Error(err)
+			return
+		}
+
+		ps := "%.1f%%"
+		fmt.Printf("%-4s %-5s  %-5s  %-5s  %v\n", labels[i],
+			fmt.Sprintf(ps, dp.Maximum),
+			fmt.Sprintf(ps, dp.Average),
+			fmt.Sprintf(ps, dp.Minimum),
+			dp.Timestamp)
+	}
+}
+
+func getMetrics(name string) (*Datapoint, error) {
+	data, err := ConvoxGet(fmt.Sprintf("/top/%s", name))
 
 	if err != nil {
-		stdcli.Error(err)
-		return
+		return nil, err
 	}
 
 	var ms MetricStatistics
@@ -47,17 +68,8 @@ func cmdTop(c *cli.Context) {
 	err = json.Unmarshal(data, &ms)
 
 	if err != nil {
-		stdcli.Error(err)
-		return
+		return nil, err
 	}
 
-	dp := ms.Datapoints[0]
-
-	ps := "%.1f"
-	fmt.Println("MAX    AVG    MIN")
-	fmt.Printf("%-5s  %-5s  %-5s\n", fmt.Sprintf(ps, dp.Maximum), fmt.Sprintf(ps, dp.Average), fmt.Sprintf(ps, dp.Minimum))
-}
-
-func round(f float64) float64 {
-	return math.Floor(f + .5)
+	return &ms.Datapoints[0], nil
 }


### PR DESCRIPTION
Adds a `convox top` command that displays near-realtime memory and cpu stats for the ECS cluster. Maximum, average, and minimum utilization are calculated over the last 1 minute.

```
$ convox top
     MAX    AVG    MIN    UPDATED
CPU  24.9%  12.8%  2.9%   2015-08-29 07:26:00 +0000 UTC
MEM  2.4%   2.2%   1.9%   2015-08-29 07:26:00 +0000 UTC
```

Depends on https://github.com/convox/kernel/pull/139