### PR TITLE
convox ps top

### DIFF
--- a/convox/ps.go
+++ b/convox/ps.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/convox/cli/Godeps/_workspace/src/github.com/codegangsta/cli"
+	"github.com/convox/cli/Godeps/_workspace/src/github.com/dustin/go-humanize"
 	"github.com/convox/cli/stdcli"
-	"github.com/dustin/go-humanize"
 )
 
 type GetMetricStatisticsOutput struct {

--- a/convox/ps.go
+++ b/convox/ps.go
@@ -115,7 +115,7 @@ func cmdPsTop(c *cli.Context) {
 
 	process := c.Args()[0]
 
-	data, err := ConvoxGet(fmt.Sprintf("/apps/%s/processes/%s/top", app, process))
+	data, err := ConvoxGet(fmt.Sprintf("/apps/%s/process_types/%s/top", app, process))
 
 	if err != nil {
 		stdcli.Error(err)


### PR DESCRIPTION
Requests and prints CPU and Memory utilization stats for a specific service. Depends on https://github.com/convox/kernel/pull/146

I think there's still a fair bit of testing, deduping, and refactoring that could be done here, but I wanted to get a first pass out the door, and this seems to work pretty well.

Usage example:
```
$ convox ps top web
     MIN    AVG    MAX    UPDATED
CPU  0.1%   0.1%   0.1%   2 minutes ago
MEM  43.0%  43.9%  44.9%  2 minutes ago
```